### PR TITLE
Add table constraints slot and functions that add to it

### DIFF
--- a/lisp/orm-column.el
+++ b/lisp/orm-column.el
@@ -25,17 +25,10 @@
 	 (when (oref column not-null) '(:not-null)))))
 
 (defun orm-column--fk-constraint (name fk)
-  (pcase-let* ((`(:references ,table ,id) fk)
+  (pcase-let* ((`(quote (:references ,table ,id)) fk)
 	       (table-name (orm-table-name table))
 	       (table-key (or (orm-table-primary-key table) [id])))
     (list :foreign-key (vector name) :references table-name table-key)))
-
-(cl-defmethod orm-column-table-constraint ((column orm-column))
-  (let ((name (oref column :name))
-	(fk (oref column :foreign-key)))
-    (cond
-     (fk (orm-column--fk-constraint name fk))
-     (t nil))))
 
 ;; For macros
 
@@ -47,6 +40,12 @@
 				       :type :documentation
 				       :custom :label
 				       :group :printer))))
+
+(defun orm-column--table-constraint-from-spec (sname soptions)
+  (let ((fk (plist-get soptions :foreign-key)))
+    (cond
+     (fk (orm-column--fk-constraint sname fk))
+     (t nil))))
 
 (defun orm-column--form-from-spec (sname soptions)
   `(orm-column :name (quote ,sname)

--- a/lisp/orm-table.el
+++ b/lisp/orm-table.el
@@ -22,7 +22,13 @@
 		 :accessor orm-table-associations
 		 :allocation :class
 		 :documentation
-		 "A list of association objects."))
+		 "A list of association objects.")
+   (table-constraints :initarg :table-constraints
+		      :type list
+		      :accessor orm-table-constraints
+		      :allocation :class
+		      :documentation
+		      "A list of table constraints."))
   :documentation
   "This special class enables persistence through a database."
   :abstract t)
@@ -51,17 +57,13 @@
   "Get column constraints for table"
   (apply 'vector (mapcar 'orm-column-constraint cols)))
 
-(defun orm-table--table-constraints (cols)
-  "Get column constraints for table"
-  (-filter 'identity (mapcar 'orm-column-table-constraint cols)))
-
 (cl-defmethod orm-table-schema ((table (subclass orm-table)))
   "Get schema for table which is made up of a vector of column constraints,
 and table constraints"
   (let* ((table (make-instance table))
 	 (cols (orm-table-columns table))
 	 (col-constraints (orm-table--column-constraints cols))
-	 (table-constraints (orm-table--table-constraints cols)))
+	 (table-constraints (orm-table-constraints table)))
     (cons col-constraints table-constraints)))
 
 (provide 'orm-table)


### PR DESCRIPTION
Adds a table-constraints slot to the orm-table class, and adds to it when there is a column with a foreign-key constraint, or when an association adds a column that has a foreign-key constraint.